### PR TITLE
Add CreateBindingJob endpoint to public API

### DIFF
--- a/static/api/v2.yaml
+++ b/static/api/v2.yaml
@@ -1797,8 +1797,8 @@ paths:
                     issuer_user_id: 4dfb7751-46a9-4bd6-a591-a5941cb24eba
                     delivery_method: SHORT_CODE
                     short_code_delivery_details:
-                      short_code: 123456789
-                      expire_time: 2022-08-12T05:53:07.119Z
+                      short_code: '123456789'
+                      expire_time: '2022-08-12T05:53:07.119Z'
         '400':
           description: Bad request.
           content:


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../contributor-guide/contributor-guide.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **main**. For more information about branches, see [Understanding doc branches](../README.md#doc-branches). 
      
- [x] If this PR relates to GitHub issues in `customer-docs` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)

This adds the CreateBindingJob endpoint to the OpenAPI spec and bumps the version to 2.3.0 (from 2.2.0).

This API endpoint was released in service version 2.86.