### PR TITLE
Add Platform Authenticator v2.112.1 release notes (June 29, 2026)

### DIFF
--- a/docs/release-notes/endpoint.mdx
+++ b/docs/release-notes/endpoint.mdx
@@ -20,6 +20,27 @@ hide_table_of_contents: true
 Secure Access release notes are published biweekly for commercial deployments in both the US and EU. FedRAMP and government environments receive updates two weeks after features are released to commercial deployments.
 
 
+### June 29, 2026
+
+<details>
+  <summary><p>v2.112.1 Beyond Identity Authenticator Release Notes</p></summary>
+
+Beyond Identity began rolling out the new **Platform Authenticator v2.112.1** release on **June 29, 2026**.
+
+<br/>
+
+### Bug Fixes
+
+| Platform | Bug Fix | Description |
+|----------|---------|-------------|
+| **Windows** | **Credentials Incorrectly Marked Invalid After Update** | Resolved an issue where valid credentials could be incorrectly marked invalid after updating the Platform Authenticator on Windows to 2.112.0, blocking sign-in. Only a small subset of credentials were affected, and they return to active automatically the next time the authenticator launches — no re-enrollment required. |
+
+<br/>
+
+<br/>
+</details>
+
+
 ### June 19, 2026
 
 <details>


### PR DESCRIPTION
Adds a standalone release-notes entry for **Platform Authenticator v2.112.1** (rolled out June 29, 2026).

### Change
- New dated section in `docs/release-notes/endpoint.mdx` above the v2.112.0 entry.
- Single Windows bug fix (ENDP-1660): valid credentials could be incorrectly marked invalid after updating to 2.112.0, blocking sign-in. Affected credentials return to active automatically on next launch — no re-enrollment required.

### Source
- Linear: ENDP-1660

🤖 Generated with [Claude Code](https://claude.com/claude-code)